### PR TITLE
Remove trailing slash causing server urls to be incorrect for cloud functions

### DIFF
--- a/packages/noodl-cloudservice/src/parse.ts
+++ b/packages/noodl-cloudservice/src/parse.ts
@@ -36,7 +36,7 @@ export function createNoodlParseServer({
   functionOptions,
   parseOptions = {},
 }: NoodlParseServerOptions): NoodlParseServerResult {
-  const serverURL = `http://localhost:${port}/`;
+  const serverURL = `http://localhost:${port}`;
 
   const logger = new LoggerAdapter({
     databaseURI


### PR DESCRIPTION
Cloud Functions do not work on current code base. 
Removing the trailing slash from the serverUrl object in the config solves this. 